### PR TITLE
adjust scheme to have base url

### DIFF
--- a/src/easymcp/client/ClientManager.py
+++ b/src/easymcp/client/ClientManager.py
@@ -130,7 +130,7 @@ class ClientManager:
                     "http",
                     "https",
                 ):
-                    resource.uri = AnyUrl(f"mcp-{name}+{resource.uri}")
+                    resource.uri = AnyUrl(f"mcp://{name}+{resource.uri}")
 
                 result.append(resource)
 


### PR DESCRIPTION
CC @evalstate 

fixes a URL scheme issue where having an _ in the server name will cause invalid URLs to be generated and break pydantic AnyUrl